### PR TITLE
Add classNames to replace React.addons.classSet

### DIFF
--- a/src/classNames.ts
+++ b/src/classNames.ts
@@ -1,0 +1,33 @@
+/**
+ * A utility to concatenate multiple classNames into a single string.
+ * The first parameter may also be a "classSet", an object with classNames
+ * as keys mapping to boolean values indicating whether or not the given
+ * className should be included.
+ * @param  {(ClassSet | string)} arg - classSet or first className
+ * @param  {...string} className - extra className to append
+ * @return {string} the complete concatenated className
+ */
+function classNames(
+    arg: ({ [key: string]: boolean } | string),
+    ...extraClasses: string[]): string {
+
+  var className = "";
+  if (typeof arg === "object") {
+    for (var name in arg) {
+      if (arg.hasOwnProperty(name) && arg[name]) {
+        className += " " + name;
+      }
+    }
+  } else {
+    className = " " + arg;
+  }
+
+  var i: number;
+  for (i = 0; i < extraClasses.length; ++i) {
+    className += " " + extraClasses[i];
+  }
+  return className.substr(1);
+}
+
+export = classNames;
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
  * TsUtil Exports
  */
 export import arrayFind = require("./arrayFind");
+export import classNames = require("./classNames");
 export import collections = require("./collections");
 export import Handle = require("./handle");
 export import identity = require("./identity");

--- a/test/classNames_spec.ts
+++ b/test/classNames_spec.ts
@@ -1,0 +1,31 @@
+import chai = require("chai");
+import tsutil = require("../src/index");
+
+var cx = tsutil.classNames;
+var assert = chai.assert;
+
+describe("classNames", () => {
+
+  it("should filter to return only truthy strings", () => {
+    assert.equal(cx({
+      foo: true,
+      bar: undefined,
+      baz: true,
+      fire: null,
+      foobar: false
+    }), "foo baz");
+  });
+
+  it("should append extra class strings", () => {
+    assert.equal(cx({
+      baz: false,
+      boo: true,
+      bar: true
+    }, "a", "b", "c"), "boo bar a b c");
+  });
+
+  it("should also accept a string as the first argument", () => {
+    assert.equal(cx("foobar", "foo", "baz"), "foobar foo baz");
+  });
+});
+


### PR DESCRIPTION
I figure that this is a better place to put this utility than in `luna-ui/src/framework`. This version will also let you concatenate multiple classNames instead of just taking the one "classSet" argument.
