### PR TITLE
Add E extends Error type parameter to Try

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -8,6 +8,7 @@ import gulp = require("gulp");
 import istanbul = require("gulp-istanbul");
 import mocha = require("gulp-mocha");
 import path = require("path");
+import replace = require("gulp-replace");
 import tsfmt = require("typescript-formatter");
 import tslint = require("gulp-tslint");
 import typedoc = require("gulp-typedoc");
@@ -161,6 +162,7 @@ gulp.task("scripts", ["clean"], (callback) => {
  */
 gulp.task("spec", ["scripts"], (callback) => {
     gulp.src(path.join(dirs.build, dirs.src, globs.js))
+        .pipe(replace(/^(var __extends =)/, "/* istanbul ignore next */\n$1"))
         .pipe(istanbul({
             includeUntested: true
         }))

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-gh-pages": "^0.4.0",
     "gulp-istanbul": "^0.5.0",
     "gulp-mocha": "^2.0.0",
+    "gulp-replace": "^0.5.3",
     "gulp-tslint": "^1.4.3",
     "gulp-typedoc": "^1.0.6",
     "gulp-typescript": "^2.4.2",

--- a/src/try.ts
+++ b/src/try.ts
@@ -1,12 +1,10 @@
+import Either = require("./either");
 import Optional = require("./optional");
 
 /**
  * The Try class is used to represent an error xor a value
  */
-class Try<E extends Error, T> {
-    private _err: E;
-    private _value: T;
-
+class Try<E extends Error, T> extends Either<E, T> {
     /**
      * Attempts to flatten an array of tries
      * @param tries The list of tries to flatten
@@ -60,22 +58,16 @@ class Try<E extends Error, T> {
         return new Try<E, T>(err, null);
     }
 
-    /**
-     * Creates a new Try assuming success
-     * @param value The value for the Try
-     * @param err The optional error that will override the value
-     */
-    constructor(err: E, value: T) {
-        this._value = value;
-        this._err = err;
+    error(): Optional<E> {
+        return this.left();
     }
 
     /**
-     * The error of the try
+     * The error of the try or null if it does not exist
      * @returns {Error}
      */
-    error(): E {
-        return this._err;
+    errorOrNull(): E {
+        return this.leftOrNull();
     }
 
     /**
@@ -83,7 +75,7 @@ class Try<E extends Error, T> {
      * @returns {boolean}
      */
     isFailure(): boolean {
-        return this._err !== null;
+        return this.isLeft();
     }
 
     /**
@@ -91,7 +83,7 @@ class Try<E extends Error, T> {
      * @returns {boolean}
      */
     isSuccess(): boolean {
-        return !this.isFailure();
+        return this.isRight();
     }
 
     /**
@@ -100,10 +92,15 @@ class Try<E extends Error, T> {
      * @returns {*}
      */
     filter(predicate: (value: T) => boolean): Try<Error, T> {
-        if (this.isFailure() || predicate(this._value)) {
+        return this.transform((err: E) => {
             return this;
-        }
-        return Try.failure<Error, T>(new Error("Try#filter(): No such element"));
+        }, (value: T) => {
+            if (predicate(value)) {
+                return this;
+            } else {
+                return Try.failure<Error, T>(new Error("Try#filter(): No such element"));
+            }
+        });
     }
 
     /**
@@ -111,9 +108,7 @@ class Try<E extends Error, T> {
      * @param callback The callback for the value
      */
     forEach(callback: (value: T) => any): void {
-        if (this.isSuccess()) {
-            callback(this._value);
-        }
+        this.value().forEach(callback);
     }
 
     /**
@@ -122,12 +117,13 @@ class Try<E extends Error, T> {
      * @returns {Try<U>}
      */
     map<U>(mapper: (value: T) => U): Try<Error, U> {
-        if (this.isSuccess()) {
+        return this.value().map((value: T) => {
             return Try.attempt<Error, U>(() => {
-                return mapper(this._value);
+                return mapper(value);
             });
-        }
-        return (<Try<E, U>><{}>this);
+        }).getOrElse(() => {
+            return <Try<E, U>><{}>this;
+        });
     }
 
     /**
@@ -136,20 +132,26 @@ class Try<E extends Error, T> {
      * @returns {Try<U>}
      */
     flatMap<F extends E, U>(mapper: (value: T) => Try<F, U>): Try<E, U> {
-        if (this.isSuccess()) {
-            return mapper(this._value);
-        }
-        return (<Try<E, U>><{}>this);
+        return this.value().map((value: T): Try<E, U> => {
+            return mapper(value);
+        }).getOrElse(() => {
+            return <Try<E, U>><{}>this;
+        });
+    }
+
+    get(): Optional<T> {
+        return this.value();
     }
 
     /**
      * Access the value or throw the error
      */
     getOrThrow(): T {
-        if (this.isFailure()) {
-            throw this._err;
+        if (this.isSuccess()) {
+            return this.value().getOrThrow();
+        } else {
+            throw this.error().getOrThrow();
         }
-        return this._value;
     }
 
     /**
@@ -158,10 +160,9 @@ class Try<E extends Error, T> {
      * @returns {*}
      */
     getOrElse<U extends T>(other: (err: E) => U): T {
-        if (this.isSuccess()) {
-            return this._value;
-        }
-        return other(this._err);
+        return this.value().getOrElse(() => {
+            return other(this.error().getOrThrow());
+        });
     }
 
     /**
@@ -170,10 +171,9 @@ class Try<E extends Error, T> {
      * @returns {*}
      */
     orElse<U extends T>(other: (err: E) => Try<E, U>): Try<Error, T> {
-        if (this.isSuccess()) {
-            return this;
-        }
-        return other(this._err);
+        return this.value().map(() => this).getOrElse(() => {
+            return other(this.error().getOrThrow());
+        });
     }
 
     /**
@@ -181,10 +181,7 @@ class Try<E extends Error, T> {
      * @returns {*}
      */
     toOptional(): Optional<T> {
-        if (this.isSuccess()) {
-            return new Optional(this._value);
-        }
-        return Optional.NONE;
+        return this.value();
     }
 
     /**
@@ -193,11 +190,12 @@ class Try<E extends Error, T> {
      * @param onFailure The callback for when the try is failed
      * @returns {Try<U>}
      */
-    transform<F extends Error, U>(onSuccess: (value: T) => Try<F, U>, onFailure: (err: Error) => Try<F, U>): Try<F, U> {
-        if (this.isSuccess()) {
-            return onSuccess(this._value);
-        }
-        return onFailure(this._err);
+    transform<F extends Error, U>(onFailure: (err: Error) => Try<F, U>, onSuccess: (value: T) => Try<F, U>): Try<F, U> {
+        return this.fold(onFailure, onSuccess);
+    }
+
+    value(): Optional<T> {
+        return this.right();
     }
 }
 

--- a/src/try.ts
+++ b/src/try.ts
@@ -3,8 +3,8 @@ import Optional = require("./optional");
 /**
  * The Try class is used to represent an error xor a value
  */
-class Try<T> {
-    private _err: Error;
+class Try<E extends Error, T> {
+    private _err: E;
     private _value: T;
 
     /**
@@ -12,9 +12,9 @@ class Try<T> {
      * @param tries The list of tries to flatten
      * @returns {Try<T[]>}
      */
-    static all<T>(tries: Try<T>[]): Try<T[]> {
-        return Try.attempt<T[]>(() => {
-            return tries.reduce((acc: T[], elem: Try<T>) => {
+    static all<E extends Error, T>(tries: Try<E, T>[]): Try<E, T[]> {
+        return Try.attempt<E, T[]>(() => {
+            return tries.reduce((acc: T[], elem: Try<E, T>) => {
                 acc.push(elem.getOrThrow());
                 return acc;
             }, []);
@@ -29,13 +29,13 @@ class Try<T> {
      *   caught and stored.
      * @returns {Try<T>}
      */
-    static attempt<T>(fn: () => T, filter?: (err: Error) => boolean): Try<T> {
+    static attempt<E extends Error, T>(fn: () => T, filter?: (err: E) => boolean): Try<E, T> {
         try {
             var value = fn();
-            return new Try<T>(value);
+            return new Try<E, T>(null, value);
         } catch (err) {
             if (!filter || filter(err)) {
-                return new Try<T>(null, err);
+                return new Try<E, T>(err, null);
             } else {
                 throw err;
             }
@@ -47,8 +47,8 @@ class Try<T> {
      * @param value The value for the Try
      * @returns {Try<T>}
      */
-    static success<T>(value: T): Try<T> {
-        return new Try<T>(value);
+    static success<E extends Error, T>(value: T): Try<E, T> {
+        return new Try<E, T>(null, value);
     }
 
     /**
@@ -56,8 +56,8 @@ class Try<T> {
      * @param err The error for the Try
      * @returns {Try<T>}
      */
-    static failure<T>(err: Error): Try<T> {
-        return new Try<T>(null, err);
+    static failure<E extends Error, T>(err: E): Try<E, T> {
+        return new Try<E, T>(err, null);
     }
 
     /**
@@ -65,7 +65,7 @@ class Try<T> {
      * @param value The value for the Try
      * @param err The optional error that will override the value
      */
-    constructor(value: T, err: Error = null) {
+    constructor(err: E, value: T) {
         this._value = value;
         this._err = err;
     }
@@ -74,7 +74,7 @@ class Try<T> {
      * The error of the try
      * @returns {Error}
      */
-    error(): Error {
+    error(): E {
         return this._err;
     }
 
@@ -99,11 +99,11 @@ class Try<T> {
      * @param filterer A filter function to check the value against
      * @returns {*}
      */
-    filter(filterer: (value: T) => boolean): Try<T> {
-        if (this.isFailure() || filterer(this._value)) {
+    filter(predicate: (value: T) => boolean): Try<Error, T> {
+        if (this.isFailure() || predicate(this._value)) {
             return this;
         }
-        return Try.failure<T>(new Error("Try.filter: No such element"));
+        return Try.failure<Error, T>(new Error("Try#filter(): No such element"));
     }
 
     /**
@@ -121,13 +121,13 @@ class Try<T> {
      * @param mapper A map function to create the new value
      * @returns {Try<U>}
      */
-    map<U>(mapper: (value: T) => U): Try<U> {
+    map<U>(mapper: (value: T) => U): Try<Error, U> {
         if (this.isSuccess()) {
-            return Try.attempt<U>(() => {
+            return Try.attempt<Error, U>(() => {
                 return mapper(this._value);
             });
         }
-        return (<Try<U>><{}>this);
+        return (<Try<E, U>><{}>this);
     }
 
     /**
@@ -135,11 +135,11 @@ class Try<T> {
      * @param mapper A map function that returns a try
      * @returns {Try<U>}
      */
-    flatMap<U>(mapper: (value: T) => Try<U>): Try<U> {
+    flatMap<F extends E, U>(mapper: (value: T) => Try<F, U>): Try<E, U> {
         if (this.isSuccess()) {
             return mapper(this._value);
         }
-        return (<Try<U>><{}>this);
+        return (<Try<E, U>><{}>this);
     }
 
     /**
@@ -157,7 +157,7 @@ class Try<T> {
      * @param other The fallback accessor
      * @returns {*}
      */
-    getOrElse<U extends T>(other: (err: Error) => U): T {
+    getOrElse<U extends T>(other: (err: E) => U): T {
         if (this.isSuccess()) {
             return this._value;
         }
@@ -169,11 +169,11 @@ class Try<T> {
      * @param other The fallback try accessor
      * @returns {*}
      */
-    orElse<U extends T>(other: () => Try<U>): Try<T> {
+    orElse<U extends T>(other: (err: E) => Try<E, U>): Try<Error, T> {
         if (this.isSuccess()) {
             return this;
         }
-        return other();
+        return other(this._err);
     }
 
     /**
@@ -193,7 +193,7 @@ class Try<T> {
      * @param onFailure The callback for when the try is failed
      * @returns {Try<U>}
      */
-    transform<U>(onSuccess: (value: T) => Try<U>, onFailure: (err: Error) => Try<U>): Try<U> {
+    transform<F extends Error, U>(onSuccess: (value: T) => Try<F, U>, onFailure: (err: Error) => Try<F, U>): Try<F, U> {
         if (this.isSuccess()) {
             return onSuccess(this._value);
         }

--- a/src/try.ts
+++ b/src/try.ts
@@ -96,7 +96,7 @@ class Try<E extends Error, T> extends Either<E, T> {
      * @returns {*}
      */
     filter(predicate: (value: T) => boolean): Try<Error, T> {
-        return this.transform((err: E) => {
+        return this.fold<Try<Error, T>>((err: E) => {
             return this;
         }, (value: T) => {
             if (predicate(value)) {
@@ -152,16 +152,6 @@ class Try<E extends Error, T> extends Either<E, T> {
         return this.value().map(() => this).getOrElse(() => {
             return other(this.error().getOrThrow());
         });
-    }
-
-    /**
-     * Transforms a try based on the success and failure conditions
-     * @param onSuccess The callback for when the try is successful
-     * @param onFailure The callback for when the try is failed
-     * @returns {Try<U>}
-     */
-    transform<F extends Error, U>(onFailure: (err: Error) => Try<F, U>, onSuccess: (value: T) => Try<F, U>): Try<F, U> {
-        return this.fold(onFailure, onSuccess);
     }
 
     /**

--- a/src/try.ts
+++ b/src/try.ts
@@ -12,8 +12,8 @@ class Try<E extends Error, T> extends Either<E, T> {
      */
     static all<E extends Error, T>(tries: Try<E, T>[]): Try<E, T[]> {
         return Try.attempt<E, T[]>(() => {
-            return tries.reduce((acc: T[], elem: Try<E, T>) => {
-                acc.push(elem.getOrThrow());
+            return tries.reduce((acc: T[], t: Try<E, T>) => {
+                acc.push(t.valueOrThrow());
                 return acc;
             }, []);
         });
@@ -58,6 +58,10 @@ class Try<E extends Error, T> extends Either<E, T> {
         return new Try<E, T>(err, null);
     }
 
+    /**
+     * Return an Optional of the error, or NONE if it is not defined
+     * @returns {Optional<E>}
+     */
     error(): Optional<E> {
         return this.left();
     }
@@ -139,32 +143,6 @@ class Try<E extends Error, T> extends Either<E, T> {
         });
     }
 
-    get(): Optional<T> {
-        return this.value();
-    }
-
-    /**
-     * Access the value or throw the error
-     */
-    getOrThrow(): T {
-        if (this.isSuccess()) {
-            return this.value().getOrThrow();
-        } else {
-            throw this.error().getOrThrow();
-        }
-    }
-
-    /**
-     * Retrieves the value and falls back to another value in case of error
-     * @param other The fallback accessor
-     * @returns {*}
-     */
-    getOrElse<U extends T>(other: (err: E) => U): T {
-        return this.value().getOrElse(() => {
-            return other(this.error().getOrThrow());
-        });
-    }
-
     /**
      * Retrieves the value and falls back to another try
      * @param other The fallback try accessor
@@ -177,14 +155,6 @@ class Try<E extends Error, T> extends Either<E, T> {
     }
 
     /**
-     * Converts the try to an optional. Returns Optional.NONE if the try is not successful
-     * @returns {*}
-     */
-    toOptional(): Optional<T> {
-        return this.value();
-    }
-
-    /**
      * Transforms a try based on the success and failure conditions
      * @param onSuccess The callback for when the try is successful
      * @param onFailure The callback for when the try is failed
@@ -194,8 +164,34 @@ class Try<E extends Error, T> extends Either<E, T> {
         return this.fold(onFailure, onSuccess);
     }
 
+    /**
+     * Returns an Optional of the successful value, or NONE if it is not defined.
+     * @returns {Optional<T>}
+     */
     value(): Optional<T> {
         return this.right();
+    }
+
+    /**
+     * Access the value or throw the error
+     */
+    valueOrThrow(): T {
+        if (this.isSuccess()) {
+            return this.value().getOrThrow();
+        } else {
+            throw this.error().getOrThrow();
+        }
+    }
+
+    /**
+     * Retrieves the value and falls back to another value in case of error
+     * @param other The fallback accessor
+     * @returns {*}
+     */
+    valueOrElse<U extends T>(other: (err: E) => U): T {
+        return this.value().getOrElse(() => {
+            return other(this.error().getOrThrow());
+        });
     }
 }
 

--- a/test/try_spec.ts
+++ b/test/try_spec.ts
@@ -245,24 +245,4 @@ describe("Try", () => {
             assert.notEqual(k, t);
         });
     });
-
-    describe("transform", () => {
-        it("should call the success callback on success", () => {
-            var spy = sinon.spy();
-            var t = tsutil.Try.success(VALUE);
-            var k = tsutil.Try.success(OTHER);
-            var u = t.transform(spy, () => { return k; });
-            assert.equal(u, k);
-            sinon.assert.notCalled(spy);
-        });
-
-        it("should call the failure callback on failure", () => {
-            var spy = sinon.spy();
-            var t = tsutil.Try.failure(ERR);
-            var k = tsutil.Try.success(OTHER);
-            var u = t.transform(() => { return k; }, spy);
-            assert.equal(u, k);
-            sinon.assert.notCalled(spy);
-        });
-    });
 });

--- a/test/try_spec.ts
+++ b/test/try_spec.ts
@@ -81,18 +81,13 @@ describe("Try", () => {
 
     describe("constructor", () => {
         it("should handle a value", () => {
-            var t = new tsutil.Try(VALUE);
+            var t = new tsutil.Try(null, VALUE);
             assert.equal(t.getOrThrow(), VALUE);
         });
 
         it("should handle an error", () => {
-            var t = new tsutil.Try(null, ERR);
+            var t = new tsutil.Try(ERR, null);
             assert.equal(t.error(), ERR);
-        });
-
-        it("should override the value for an error", () => {
-            var t = new tsutil.Try(null, ERR);
-            assert.isTrue(t.isFailure());
         });
     });
 

--- a/test/try_spec.ts
+++ b/test/try_spec.ts
@@ -19,7 +19,7 @@ describe("Try", () => {
         it("should return all of the values if there is not an exception", () => {
             var t = tsutil.Try.success(VALUE);
             var k = tsutil.Try.success(OTHER);
-            assert.deepEqual(tsutil.Try.all([t, k]).getOrThrow(), [VALUE, OTHER]);
+            assert.deepEqual(tsutil.Try.all([t, k]).valueOrThrow(), [VALUE, OTHER]);
         });
 
         it("should throw if there is an exception", () => {
@@ -32,7 +32,7 @@ describe("Try", () => {
     describe("#attempt", () => {
         it("should return a value if successful", () => {
             var t = tsutil.Try.attempt(VALUE_ACCESSOR);
-            assert.equal(t.getOrThrow(), VALUE);
+            assert.equal(t.valueOrThrow(), VALUE);
         });
 
         it("should handle throwing an error", () => {
@@ -61,14 +61,14 @@ describe("Try", () => {
             var t = tsutil.Try.attempt(VALUE_ACCESSOR, () => {
                 return false;
             });
-            assert.equal(t.getOrThrow(), VALUE);
+            assert.equal(t.valueOrThrow(), VALUE);
         });
     });
 
     describe("#success", () => {
         it("should return a successful Try", () => {
             var t = tsutil.Try.success(VALUE);
-            assert.equal(t.getOrThrow(), VALUE);
+            assert.equal(t.valueOrThrow(), VALUE);
         });
     });
 
@@ -82,7 +82,7 @@ describe("Try", () => {
     describe("constructor", () => {
         it("should handle a value", () => {
             var t = new tsutil.Try(null, VALUE);
-            assert.equal(t.getOrThrow(), VALUE);
+            assert.equal(t.valueOrThrow(), VALUE);
         });
 
         it("should handle an error", () => {
@@ -91,7 +91,11 @@ describe("Try", () => {
         });
     });
 
-    describe("error", () => {
+    /*describe("error", () => {
+
+    });*/
+
+    describe("errorOrNull", () => {
         it("should return the error", () => {
             var t = tsutil.Try.failure(ERR);
             assert.equal(t.errorOrNull(), ERR);
@@ -160,7 +164,7 @@ describe("Try", () => {
     describe("map", () => {
         it("should return the new value", () => {
             var t = tsutil.Try.success(VALUE).map(OTHER_ACCESSOR);
-            assert.equal(t.getOrThrow(), OTHER);
+            assert.equal(t.valueOrThrow(), OTHER);
         });
 
         it("should return a failed try if the mapper throws", () => {
@@ -191,29 +195,39 @@ describe("Try", () => {
         });
     });
 
-    describe("getOrThrow", () => {
+    describe("value", () => {
+        it("should return an optional for success", () => {
+            assert.equal(tsutil.Try.success(VALUE).value().getOrThrow(), VALUE);
+        });
+
+        it("should return NONE for failure", () => {
+            assert.equal(tsutil.Try.failure(ERR).value(), tsutil.Optional.NONE);
+        });
+    });
+
+    describe("valueOrThrow", () => {
         it("should return the value for success", () => {
             var t = tsutil.Try.success(VALUE);
-            assert.equal(t.getOrThrow(), VALUE);
+            assert.equal(t.valueOrThrow(), VALUE);
         });
 
         it("should throw for failure", () => {
             assert.throws(() => {
-                tsutil.Try.failure(ERR).getOrThrow();
+                tsutil.Try.failure(ERR).valueOrThrow();
             });
         });
     });
 
-    describe("getOrElse", () => {
+    describe("valueOrElse", () => {
         it("should return value for success", () => {
             var t = tsutil.Try.success(VALUE);
-            var k = t.getOrElse(OTHER_ACCESSOR);
+            var k = t.valueOrElse(OTHER_ACCESSOR);
             assert.equal(k, VALUE);
         });
 
         it("should return other for failure", () => {
             var t = tsutil.Try.failure(ERR);
-            var k = t.getOrElse(OTHER_ACCESSOR);
+            var k = t.valueOrElse(OTHER_ACCESSOR);
             assert.equal(k, OTHER);
         });
     });
@@ -229,16 +243,6 @@ describe("Try", () => {
             var t = tsutil.Try.failure(ERR);
             var k = t.orElse(() => { return tsutil.Try.success(OTHER); });
             assert.notEqual(k, t);
-        });
-    });
-
-    describe("toOptional", () => {
-        it("should return an optional for success", () => {
-            assert.equal(tsutil.Try.success(VALUE).toOptional().getOrThrow(), VALUE);
-        });
-
-        it("should return NONE for failure", () => {
-            assert.equal(tsutil.Try.failure(ERR).toOptional(), tsutil.Optional.NONE);
         });
     });
 

--- a/test/try_spec.ts
+++ b/test/try_spec.ts
@@ -39,14 +39,14 @@ describe("Try", () => {
             var t = tsutil.Try.attempt(() => {
                 throw ERR;
             });
-            assert.equal(t.error(), ERR);
+            assert.equal(t.errorOrNull(), ERR);
         });
 
         it("should handle a positive filter", () => {
             var t = tsutil.Try.attempt(() => {
                 throw ERR;
             }, () => { return true; });
-            assert.equal(t.error(), ERR);
+            assert.equal(t.errorOrNull(), ERR);
         });
 
         it("should handle a negative filter", () => {
@@ -75,7 +75,7 @@ describe("Try", () => {
     describe("#failure", () => {
         it("should return a failed Try", () => {
             var t = tsutil.Try.failure(ERR);
-            assert.equal(t.error(), ERR);
+            assert.equal(t.errorOrNull(), ERR);
         });
     });
 
@@ -87,14 +87,14 @@ describe("Try", () => {
 
         it("should handle an error", () => {
             var t = new tsutil.Try(ERR, null);
-            assert.equal(t.error(), ERR);
+            assert.equal(t.errorOrNull(), ERR);
         });
     });
 
     describe("error", () => {
         it("should return the error", () => {
             var t = tsutil.Try.failure(ERR);
-            assert.equal(t.error(), ERR);
+            assert.equal(t.errorOrNull(), ERR);
         });
     });
 
@@ -165,7 +165,7 @@ describe("Try", () => {
 
         it("should return a failed try if the mapper throws", () => {
             var t = tsutil.Try.success(VALUE).map(() => { throw ERR; });
-            assert.equal(t.error(), ERR);
+            assert.equal(t.errorOrNull(), ERR);
         });
 
         it("should not call the new value if the try is failed", () => {
@@ -247,7 +247,7 @@ describe("Try", () => {
             var spy = sinon.spy();
             var t = tsutil.Try.success(VALUE);
             var k = tsutil.Try.success(OTHER);
-            var u = t.transform(() => { return k; }, spy);
+            var u = t.transform(spy, () => { return k; });
             assert.equal(u, k);
             sinon.assert.notCalled(spy);
         });
@@ -256,7 +256,7 @@ describe("Try", () => {
             var spy = sinon.spy();
             var t = tsutil.Try.failure(ERR);
             var k = tsutil.Try.success(OTHER);
-            var u = t.transform(spy, () => { return k; });
+            var u = t.transform(() => { return k; }, spy);
             assert.equal(u, k);
             sinon.assert.notCalled(spy);
         });

--- a/tsd.json
+++ b/tsd.json
@@ -52,6 +52,9 @@
     },
     "gulp-gh-pages/gulp-gh-pages.d.ts": {
       "commit": "84db5f1b5934ab9048185e784a34c545f1d705af"
+    },
+    "gulp-replace/gulp-replace.d.ts": {
+      "commit": "57340eca1e3aac68d59cc981b441da834ca38235"
     }
   }
 }


### PR DESCRIPTION
- Add the E type parameter
- Have it extend `Either`
- Rename `get*` to `value*`
- Remove `transform` method
- Rename `error` to `errorOrNull`
- Have `error` return an `Optional`, like `Either`s.
