### PR TITLE
Prevent perishable nodes from being double-released

### DIFF
--- a/src/perishable.ts
+++ b/src/perishable.ts
@@ -47,10 +47,17 @@ class PerishableNode<T> implements Handle<T> {
     }
 
     release(): void {
+        if (this._isReleased) {
+            throw new Error("Only release a perishable node once");
+        }
         this._prev._setNext(this._next);
         if (this._hasNext()) {
             this._next._setPrev(this._prev);
         }
+        // Perishable nodes should only be released once but in case we strip assertions we want to make sure that we
+        // don't accidentally add _next into _prev's list if we are removed twice.
+        this._prev = null;
+        this._next = null;
         this._isReleased = true;
     }
 
@@ -119,7 +126,7 @@ class Perishable<T> {
     }
 
     /**
-     * Make the reference stale and notify all handles
+     * Make the reference stale and notify all handles. Safe to call more than once.
      */
     makeStale(): void {
         if (!this.isStale()) {

--- a/test/perishable_spec.ts
+++ b/test/perishable_spec.ts
@@ -58,6 +58,15 @@ describe("Perishable", () => {
             handle.release();
             assert(handle.isReleased());
         });
+
+        it("should assert if release() is called twice", () => {
+            var perishable = new tsutil.Perishable(VALUE, sinon.spy(), sinon.spy());
+            var handle = perishable.createHandle(null);
+            handle.release();
+            assert.throws(() => {
+                handle.release();
+            }, /Only release a perishable node once/);
+        });
     });
 
     describe("createHandle", () => {


### PR DESCRIPTION
This would cause crazy bugs where released nodes would wind up back in the list of handles.
