### PR TITLE
Bump tslint version (and fix breaking change)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "precompile": "npm run clean",
     "compile": "find src test typings -name \"*.ts\" | xargs tsc --declaration --module commonjs --target es5 --noImplicitAny --outDir build",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "lint": "find src test -name \"*.ts\" | sed 's/^/--file=/g' | xargs tslint",
+    "lint": "find src test -name \"*.ts\" | xargs tslint",
     "setup": "rm -rf node_modules typings && npm install && npm run typings",
     "pretest": "npm run compile -- --sourceMap && find build -type f -name *.js -exec sed -i .bak -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/; 1s/^/require(\"source-map-support\").install();\r/' {} \\;",
     "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --recursive build/**/*_test.js",
@@ -62,7 +62,7 @@
     "sinon": "^1.14.1",
     "source-map-support": "^0.2.10",
     "tsd": "^0.6.0-beta.5",
-    "tslint": "^2.1.1",
+    "tslint": "^2.4.2",
     "typescript": "^1.4.1"
   },
   "typescript": {


### PR DESCRIPTION
tslint updated, which broke `npm run lint`. This pushes us to the latest
version, and updates the npm lint script accordingly.
